### PR TITLE
Get url

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,4 +16,18 @@ Click on the refresh icon if you make a change to the file.
 
 You should be able to use the extension through the browser now.
 
+------------------
+As of Oct 31:
+We can get the user's url using the content.js script or the background.js script. I've implemented both for now.
+
+To use:
+- pull the changes and reload the extension in chrome://extensions.
+- there will be two buttons in the extension popup. Click the first button to get the h1 text and the current url 
+(from content.js) or click the second button to get the url (from background.js). They should be displayed as lines of 
+text in the popup.
+
+Also, we can restrict when we want our extension to only do things when 
+on certain sites by checking the url with regex (there is an example in the background.js file) or we can restrict 
+where the content.js file should work in the manifest.json using the "matches" key under "content_scripts". 
+
 

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -1,1 +1,35 @@
 console.log("background.js is executed when extension is installed or refreshed");
+
+const listOfInjectableURLRegex = [ // change these to the list of allowed news sources
+    "^https:\\/\\/www\\.google",
+    "^https:\\/\\/www\\.youtube\\.com",
+    "^https:\\/\\/www\\.stackoverflow\\.com",
+    "^https:\\/\\/www\\.bbc\\.com\\/news\\/"
+]
+
+chrome.tabs.onActivated.addListener(tab => {
+    console.log(tab); // will print out tabId and windowId as tab object in the background console
+    chrome.tabs.get(tab.tabId, activeTabObject => {
+        console.log(activeTabObject.url); // will print out active tab info in the background console
+        if (testActiveUrlAgainstListOfInjectableURLRegex(activeTabObject.url)) { // inject script if on google.com (for testing, change this)
+            try {
+                chrome.tabs.executeScript(null, {file: './foreground.js'},() => {
+                    console.log('injected foreground');
+                });
+            } catch (e) {
+                console.log('Error when executing foreground.js from background', e);
+            }
+        }
+    });
+});
+
+function testActiveUrlAgainstListOfInjectableURLRegex(activeTabUrl) {
+    let allowedUrl = false;
+    listOfInjectableURLRegex.forEach(r => {
+        const re = new RegExp(r);
+        if (re.test(activeTabUrl)) {
+            allowedUrl = true;
+        }
+    });
+    return allowedUrl;
+}

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -11,7 +11,7 @@ chrome.tabs.onActivated.addListener(tab => {
     console.log(tab); // will print out tabId and windowId as tab object in the background console
     chrome.tabs.get(tab.tabId, activeTabObject => {
         console.log(activeTabObject.url); // will print out active tab info in the background console
-        if (testActiveUrlAgainstListOfInjectableURLRegex(activeTabObject.url)) { // inject script if on google.com (for testing, change this)
+        if (testActiveUrlAgainstListOfInjectableURLRegex(activeTabObject.url)) {
             try {
                 chrome.tabs.executeScript(null, {file: 'frontend/foreground.js'}, // can also do executeCSS
                     () => console.log('background: injected foreground.js')

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -21,15 +21,15 @@ chrome.tabs.onActivated.addListener(tab => {
             }
         }
     });
+});
 
-    chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
-        if (message.request === 'toBkg') {
-            chrome.tabs.get(tab.tabId, activeTabObject => {
-                sendResponse({currentUrl: activeTabObject?.url});
-            });
-        }
-        return true;
-    });
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+    if (message.request === 'toBkg') {
+        chrome.tabs.query({ active: true, currentWindow: true}, function(tabs) {
+            sendResponse({currentUrl: tabs[0]?.url});
+        });
+    }
+    return true;
 });
 
 function testActiveUrlAgainstListOfInjectableURLRegex(activeTabUrl) {

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -13,9 +13,9 @@ chrome.tabs.onActivated.addListener(tab => {
         console.log(activeTabObject.url); // will print out active tab info in the background console
         if (testActiveUrlAgainstListOfInjectableURLRegex(activeTabObject.url)) { // inject script if on google.com (for testing, change this)
             try {
-                chrome.tabs.executeScript(null, {file: 'frontend/foreground.js'},() => {
-                    console.log('injected foreground');
-                });
+                chrome.tabs.executeScript(null, {file: 'frontend/foreground.js'}, // can also do executeCSS
+                    () => console.log('background: injected foreground.js')
+                );
             } catch (e) {
                 console.log('Error when executing foreground.js from background', e);
             }
@@ -23,13 +23,12 @@ chrome.tabs.onActivated.addListener(tab => {
     });
 
     chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
-        console.log("geturl!!!!")
         if (message.request === 'toBkg') {
             chrome.tabs.get(tab.tabId, activeTabObject => {
-                console.log("getUrl listener activeTabObject.url", activeTabObject.url); // will print out active tab info in the background console
-                sendResponse({currentUrl: activeTabObject.url});
+                sendResponse({currentUrl: activeTabObject?.url});
             });
         }
+        return true;
     });
 });
 

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -13,12 +13,22 @@ chrome.tabs.onActivated.addListener(tab => {
         console.log(activeTabObject.url); // will print out active tab info in the background console
         if (testActiveUrlAgainstListOfInjectableURLRegex(activeTabObject.url)) { // inject script if on google.com (for testing, change this)
             try {
-                chrome.tabs.executeScript(null, {file: './foreground.js'},() => {
+                chrome.tabs.executeScript(null, {file: 'frontend/foreground.js'},() => {
                     console.log('injected foreground');
                 });
             } catch (e) {
                 console.log('Error when executing foreground.js from background', e);
             }
+        }
+    });
+
+    chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+        console.log("geturl!!!!")
+        if (message.request === 'toBkg') {
+            chrome.tabs.get(tab.tabId, activeTabObject => {
+                console.log("getUrl listener activeTabObject.url", activeTabObject.url); // will print out active tab info in the background console
+                sendResponse({currentUrl: activeTabObject.url});
+            });
         }
     });
 });

--- a/frontend/content.css
+++ b/frontend/content.css
@@ -1,0 +1,3 @@
+h1 {
+    color: deeppink !important;
+}

--- a/frontend/content.css
+++ b/frontend/content.css
@@ -1,3 +1,4 @@
-h1 {
-    color: deeppink !important;
-}
+/*this is an example - uncomment below to turn h1 elements pink! is connected though the manifest.json file*/
+/*h1 {*/
+/*    color: deeppink !important;*/
+/*}*/

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -5,4 +5,5 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
         const url = window.location.href;
         sendResponse({firstHeadingValue: firstHeadingValue, url: url});
     }
+    return true;
 });

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -1,7 +1,6 @@
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     if (message.request === 'toContent') {
         const heading = document.getElementsByTagName("h1");
-        console.log("heading obj: ", heading);
         const firstHeadingValue = heading[0]?.innerText;
         const url = window.location.href;
         sendResponse({firstHeadingValue: firstHeadingValue, url: url});

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -1,4 +1,2 @@
 // alert('testing testing');
-chrome.runtime.onMessage.addListener(function (request) {
-    alert(request);
-})
+console.log("content.js here");

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -1,2 +1,9 @@
-// alert('testing testing');
-console.log("content.js here");
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+    if (message.request === 'toContent') {
+        const heading = document.getElementsByTagName("h1");
+        console.log("heading obj: ", heading);
+        const firstHeadingValue = heading[0]?.innerText;
+        const url = window.location.href;
+        sendResponse({firstHeadingValue: firstHeadingValue, url: url});
+    }
+});

--- a/frontend/foreground.js
+++ b/frontend/foreground.js
@@ -1,1 +1,1 @@
-console.log("run foreground");
+console.log("run foreground.js script");

--- a/frontend/options.html
+++ b/frontend/options.html
@@ -1,0 +1,1 @@
+<h1>Options go here</h1>

--- a/frontend/popup/popup.css
+++ b/frontend/popup/popup.css
@@ -1,3 +1,4 @@
+/*set the size of the popup:*/
 body {
     height: 300px;
     width: 500px;

--- a/frontend/popup/popup.html
+++ b/frontend/popup/popup.html
@@ -6,7 +6,8 @@
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
-    <button>click</button>
-    <script scr="popup.js" charset="UTF-8"></script>
+    <button id="contentClick">click to get h1 and url from content.js</button>
+    <button id="backgroundClick">click for h1 and url from background.js</button>
+    <script src="popup.js" charset="UTF-8"></script>
 </body>
 </html>

--- a/frontend/popup/popup.html
+++ b/frontend/popup/popup.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <button id="contentClick">click to get h1 and url from content.js</button>
-    <button id="backgroundClick">click for h1 and url from background.js</button>
+    <button id="backgroundClick">click for url from background.js</button>
     <script src="popup.js" charset="UTF-8"></script>
 </body>
 </html>

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
 
-    document.querySelector('button').addEventListener('click', onclick, false);
-    
+    // document.querySelector('button').addEventListener('click', onclick, false);
+
 }, false)

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,37 @@
 document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
+    document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
 
-    // document.querySelector('button').addEventListener('click', onclick, false);
+    function contentOnClick() {
+        chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
+            chrome.tabs.sendMessage(tabs[0].id, {request: 'toContent'}, null, showHeading);
+        });
+    }
+    function bkgOnClick() {
+        chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
+            chrome.tabs.sendMessage(tabs[0].id, {request: 'toBkg'}, null, showUrl);
+        });
+    }
 
-}, false)
+    function showHeading(res) {
+        if (res) {
+            const headingDiv = document.createElement('div');
+            headingDiv.textContent = res.firstHeadingValue;
+            const br = document.createElement('br');
+            const urlDiv = document.createElement('div');
+            urlDiv.textContent = res.url;
+            document.body.appendChild(headingDiv);
+            document.body.appendChild(br);
+            document.body.appendChild(urlDiv);
+        }
+    }
+
+    function showUrl(res) {
+        console.log("showUrl response: ", res);
+        const div = document.createElement('div');
+        div.textContent = res.firstHeadingValue;
+        console.log("res.currentUrl in popup.js: ");
+        document.body.appendChild(div);
+    }
+
+}, false);

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -15,21 +15,24 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function fromContent(res) {
-        if (res) {
+        if (res?.firstHeadingValue) {
             const headingDiv = document.createElement('div');
             headingDiv.textContent = res.firstHeadingValue;
             const br = document.createElement('br');
-            const urlDiv = document.createElement('div');
-            urlDiv.textContent = res.url;
             document.body.appendChild(headingDiv);
             document.body.appendChild(br);
+        }
+        if (res?.url) {
+            const urlDiv = document.createElement('div');
+            urlDiv.textContent = res.url;
+            const br = document.createElement('br');
             document.body.appendChild(urlDiv);
             document.body.appendChild(br);
         }
     }
 
     function fromBkg(res) {
-        if (res) {
+        if (res?.currentUrl) {
             const div = document.createElement('div');
             div.textContent = res.currentUrl;
             const br = document.createElement('br');

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,19 +1,20 @@
 document.addEventListener('DOMContentLoaded', function() {
+
     document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
     document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
 
     function contentOnClick() {
         chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
-            chrome.tabs.sendMessage(tabs[0].id, {request: 'toContent'}, null, showHeading);
+            chrome.tabs.sendMessage(tabs[0].id, {request: 'toContent'}, null, fromContent);
         });
     }
     function bkgOnClick() {
-        chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
-            chrome.tabs.sendMessage(tabs[0].id, {request: 'toBkg'}, null, showUrl);
+        chrome.tabs.query({currentWindow: true, active: true}, () => {
+            chrome.runtime.sendMessage({request: 'toBkg'}, fromBkg);
         });
     }
 
-    function showHeading(res) {
+    function fromContent(res) {
         if (res) {
             const headingDiv = document.createElement('div');
             headingDiv.textContent = res.firstHeadingValue;
@@ -23,15 +24,18 @@ document.addEventListener('DOMContentLoaded', function() {
             document.body.appendChild(headingDiv);
             document.body.appendChild(br);
             document.body.appendChild(urlDiv);
+            document.body.appendChild(br);
         }
     }
 
-    function showUrl(res) {
-        console.log("showUrl response: ", res);
-        const div = document.createElement('div');
-        div.textContent = res.firstHeadingValue;
-        console.log("res.currentUrl in popup.js: ");
-        document.body.appendChild(div);
+    function fromBkg(res) {
+        if (res) {
+            const div = document.createElement('div');
+            div.textContent = res.currentUrl;
+            const br = document.createElement('br');
+            document.body.appendChild(div);
+            document.body.appendChild(br);
+        }
     }
 
 }, false);

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,10 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "https://www.bbc.com/news/*"
       ],
-      "js": ["frontend/content.js"]
+      "js": ["frontend/content.js"],
+      "css": ["frontend/content.css"]
     }
   ],
   "icons": {
@@ -22,11 +23,15 @@
     "default_title": "The title"
   },
   "background": {
-    "scripts": ["frontend/background.js"]
+    "scripts": ["frontend/background.js"],
+    "persistent": false
   },
   "options_page": "frontend/options.html",
   "permissions": [
-      "tabs",
-      "<all_urls>"
+    "tabs",
+    "https://www.google.com/*",
+    "https://www.youtube.com/*",
+    "https://www.stackoverflow.com/*",
+    "*://*/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.bbc.com/news/*"
+        "<all_urls>"
       ],
       "js": ["frontend/content.js"],
       "css": ["frontend/content.css"]
@@ -29,9 +29,8 @@
   "options_page": "frontend/options.html",
   "permissions": [
     "tabs",
-    "https://www.google.com/*",
-    "https://www.youtube.com/*",
-    "https://www.stackoverflow.com/*",
-    "*://*/*"
+    "https://*/*",
+    "http://*/*",
+    "<all_urls>"
   ]
 }


### PR DESCRIPTION
We can get the user's url using the content.js script or the background.js script. I've implemented both for now.

To use:
- pull the changes and reload the extension in chrome://extensions.
- there will be two buttons in the extension popup. Click the first button to get the h1 text and the current url (from content.js) or click the second button to get the url (from background.js). They should be displayed as lines of text in the popup.

Also, we can restrict our extension to only do things when on certain sites by checking the url with regex (there is an example in the background.js file) or we can restrict where the content.js file should work in the manifest.json using the "matches" key under "content_scripts". 

closes #17 