### PR TITLE
Have different first view

### DIFF
--- a/frontend/popup/popup.html
+++ b/frontend/popup/popup.html
@@ -6,9 +6,14 @@
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
-    <button id="contentClick">click to get h1 and url from content.js</button>
-    <button id="backgroundClick">click for url from background.js</button>
-    <button id="dummyURLs">show list of dummy articles</button>
-    <script src="popup.js" charset="UTF-8"></script>
+    <div id="outerContainer">
+        <div id="childContainer">
+            <button id="contentClick">click to get h1 and url from content.js</button>
+            <button id="backgroundClick">click for url from background.js</button>
+            <button id="dummyURLs">show list of dummy articles</button>
+            <script src="popup.js" charset="UTF-8"></script>
+        </div>
+    </div>
 </body>
+
 </html>

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,24 @@
 document.addEventListener('DOMContentLoaded', function() {
 
+    chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
+        if (!result?.value) {
+            const outerContainer = document.getElementById('outerContainer');
+            const childContainer = document.getElementById('childContainer');
+            const startingDiv = `<div id="outerContainer">
+                                        <div>STARTING PAGE</div>
+                                </div>`;
+            outerContainer.innerHTML = startingDiv;
+        }
+        console.log('Value currently is ' + result?.['hasUserUsedNewsSentiment']);
+    });
+
+    chrome.storage.sync.set({'hasUserUsedNewsSentiment': 'NEW VALUE'}, function() {
+        console.log('Value is set');
+        chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
+            console.log('Value is ' + result?.['hasUserUsedNewsSentiment']);
+        });
+    });
+
     document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
     document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
     document.getElementById('dummyURLs').addEventListener('click', dummyOnClick, false);

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,27 +1,39 @@
 document.addEventListener('DOMContentLoaded', function() {
-
-    chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
-        if (!result?.value) {
-            const outerContainer = document.getElementById('outerContainer');
-            const childContainer = document.getElementById('childContainer');
-            const startingDiv = `<div id="outerContainer">
+    const startingView = `<div id="outerContainer">
                                         <div>STARTING PAGE</div>
+                                        <button id="toMain">click to set user rating to center and enter main</button>
                                 </div>`;
-            outerContainer.innerHTML = startingDiv;
+    const mainView = `<div id="childContainer">
+                                    <button id="contentClick">click to get h1 and url from content.js</button>
+                                    <button id="backgroundClick">click for url from background.js</button>
+                                    <button id="dummyURLs">show list of dummy articles</button>
+                                    <script src="popup.js" charset="UTF-8"></script>
+                               </div>`;
+    const outerContainer = document.getElementById('outerContainer');
+
+    chrome.storage.sync.get('userRating', function(result) {
+        if (!result?.['userRating']) {
+            outerContainer.innerHTML = startingView;
+            document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
         }
-        console.log('Value currently is ' + result?.['hasUserUsedNewsSentiment']);
+        console.log('Value currently is ' + result?.['userRating']);
     });
 
-    chrome.storage.sync.set({'hasUserUsedNewsSentiment': 'NEW VALUE'}, function() {
-        console.log('Value is set');
-        chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
-            console.log('Value is ' + result?.['hasUserUsedNewsSentiment']);
+    document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
+    document.getElementById('backgroundClick')?.addEventListener('click', bkgOnClick, false);
+    document.getElementById('dummyURLs')?.addEventListener('click', dummyOnClick, false);
+
+    function setUserRating() {
+        console.log("in set user rating");
+        // add a slider and allow user to set their value
+        chrome.storage.sync.set({'userRating': 'center'}, function() {
+            console.log('Value is set');
+            chrome.storage.sync.get('userRating', function(result) {
+                console.log('Value is ' + result?.['userRating']);
+            });
+            outerContainer.innerHTML = mainView;
         });
-    });
-
-    document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
-    document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
-    document.getElementById('dummyURLs').addEventListener('click', dummyOnClick, false);
+    }
 
     function contentOnClick() {
         chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -16,7 +16,6 @@ document.addEventListener('DOMContentLoaded', function() {
             outerContainer.innerHTML = startingView;
             document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
         }
-        console.log('Value currently is ' + result?.['userRating']);
     });
 
     document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
@@ -24,13 +23,8 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('dummyURLs')?.addEventListener('click', dummyOnClick, false);
 
     function setUserRating() {
-        console.log("in set user rating");
         // add a slider and allow user to set their value
         chrome.storage.sync.set({'userRating': 'center'}, function() {
-            console.log('Value is set');
-            chrome.storage.sync.get('userRating', function(result) {
-                console.log('Value is ' + result?.['userRating']);
-            });
             outerContainer.innerHTML = mainView;
         });
     }

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const startingView = `<div id="outerContainer">
+    const startingView = `<div id="childContainer">
                                         <div>STARTING PAGE</div>
                                         <button id="toMain">click to set user rating to center and enter main</button>
                                 </div>`;

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
   "options_page": "frontend/options.html",
   "permissions": [
     "tabs",
+    "storage",
     "https://*/*",
     "http://*/*",
     "<all_urls>"


### PR DESCRIPTION
closes #45 

Here is an ugly "first view" (hopefully we can get it prettier once the wireframes are decided). Clicking the button into the main view will save a user's self-rating as "center" for now.

setting innerHTML directly like this may or may not be dangerous. I will look into it / change it to the replaceChild function or just 'hide' the different views later