### PR TITLE
Have different first view

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,17 +17,10 @@ Click on the refresh icon if you make a change to the file.
 You should be able to use the extension through the browser now.
 
 ------------------
-As of Oct 31:
-We can get the user's url using the content.js script or the background.js script. I've implemented both for now.
-
-To use:
-- pull the changes and reload the extension in chrome://extensions.
-- there will be two buttons in the extension popup. Click the first button to get the h1 text and the current url 
-(from content.js) or click the second button to get the url (from background.js). They should be displayed as lines of 
-text in the popup.
-
-Also, we can restrict when we want our extension to only do things when 
-on certain sites by checking the url with regex (there is an example in the background.js file) or we can restrict 
-where the content.js file should work in the manifest.json using the "matches" key under "content_scripts". 
-
-
+As of Nov 22:
+Currently, the values are stored as either 'na', 'left', 'center-left', 'center',
+'center-right', or 'right' in chrome.storage.sync (the developer panel doesn't 
+seem show this - you might have to download the Storage Area Explorer extension
+(https://chrome.google.com/webstore/detail/storage-area-explorer/ocfjjjjhkpapocigimmppepjgfdecjkb?hl=en)) 
+to see or delete this data (there is no way currently to change a user's preference
+ from the GUI).

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -4,7 +4,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
         const firstHeadingValue = heading[0]?.innerText;
         const url = window.location.href;
         sendResponse({firstHeadingValue: firstHeadingValue, url: url});
-    } else if (message.request === 'getList') {
+    } else if (message.request === 'getArticles') {
         getData('http://localhost:8090/articles').then(data => sendResponse({ listArticles: data }));
     }
     return true;

--- a/frontend/popup/popup.css
+++ b/frontend/popup/popup.css
@@ -8,28 +8,82 @@ body {
     -webkit-appearance: none;
     width: 100%;
     height: 15px;
-    border-radius: 5px;   
+    border-radius: 5px;
     background: #d3d3d3;
     outline: none;
     opacity: 0.7;
     -webkit-transition: .2s;
     transition: opacity .2s;
-  }
-  
-  .slider::-webkit-slider-thumb {
+}
+.slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 25px;
-    height: 25px;
-    border-radius: 50%; 
-    background: #4CAF50;
-    cursor: pointer;
-  }
-  
-  .slider::-moz-range-thumb {
     width: 25px;
     height: 25px;
     border-radius: 50%;
     background: #4CAF50;
     cursor: pointer;
-  }
+}
+.slider::-moz-range-thumb {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    background: #4CAF50;
+    cursor: pointer;
+}
+
+#startingView {
+    display: none;
+}
+
+/* for the toggle switch: */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 30px;
+    height: 15px;
+}
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.toggle {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+.toggle:before {
+    position: absolute;
+    content: "";
+    height: 12px;
+    width: 12px;
+    left: 2px;
+    bottom: 2px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+input:checked + .toggle {
+    background-color: #4CAF50;
+}
+input:focus + .toggle {
+    box-shadow: 0 0 1px #4CAF50;
+}
+input:checked + .toggle:before {
+    -webkit-transform: translateX(14px);
+    -ms-transform: translateX(14px);
+    transform: translateX(14px);
+}
+.toggle.round {
+    border-radius: 15px;
+}
+.toggle.round:before {
+    border-radius: 50%;
+}

--- a/frontend/popup/popup.html
+++ b/frontend/popup/popup.html
@@ -6,16 +6,14 @@
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
-    <button id="contentClick">click to get h1 and url from content.js</button>
-    <button id="backgroundClick">click for url from background.js</button>
-    <button id="Urls">show list of dummy articles</button>
-    <script src="popup.js" charset="UTF-8"></script>
-
-    <div class="slidecontainer">
-        <input type="range" min="1" max="5" value="3" class="slider" id="myRange">
-        <p>Value: <span id="demo"></span></p>
+    <div id="outerContainer">
+        <div id="childContainer">
+            <button id="contentClick">click to get h1 and url from content.js</button>
+            <button id="backgroundClick">click for url from background.js</button>
+            <button id="Urls">show list of dummy articles</button>
+            <script src="popup.js" charset="UTF-8"></script>
+        </div>
     </div>
-    
 </body>
 
 </html>

--- a/frontend/popup/popup.html
+++ b/frontend/popup/popup.html
@@ -6,13 +6,30 @@
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
-    <div id="outerContainer">
-        <div id="childContainer">
-            <button id="contentClick">click to get h1 and url from content.js</button>
-            <button id="backgroundClick">click for url from background.js</button>
-            <button id="Urls">show list of dummy articles</button>
-            <script src="popup.js" charset="UTF-8"></script>
+    <div id="mainView">
+        <button id="contentClick">click to get h1 and url from content.js</button>
+        <button id="getArticles">show list of dummy articles</button>
+        <script src="popup.js" charset="UTF-8"></script>
+
+        <div class="slidecontainer">
+            <input type="range" min="0" max="4" value="2" class="slider" id="myRange">
+            <p>Value: <span id="demo"></span></p>
         </div>
+    </div>
+    <div id="startingView">
+        <div>Welcome! Please set your political preference below:</div>
+        <div>
+            <span>I have no political preference/I do not know my political preference</span>
+            <label class="switch">
+                <input type="checkbox" id="startingToggle">
+                <span class="toggle round"></span>
+            </label>
+        </div>
+        <div class="slidecontainer" id="slideContainer">
+            <p>My political preference is: <span id="startingSliderValue"></span></p>
+            <input type="range" min="0" max="4" value="2" class="slider" id="startingSlider">
+        </div>
+        <button id="toMain">Enter</button>
     </div>
 </body>
 

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,31 +1,27 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const startingView = `<div id="childContainer">
-                                        <div>STARTING PAGE</div>
-                                        <button id="toMain">click to set user rating to center and enter main</button>
-                                </div>`;
-    const mainView = `<div id="childContainer">
-                                    <button id="contentClick">click to get h1 and url from content.js</button>
-                                    <button id="backgroundClick">click for url from background.js</button>
-                                    <button id="dummyURLs">show list of dummy articles</button>
-                                    <script src="popup.js" charset="UTF-8"></script>
-                               </div>`;
-    const outerContainer = document.getElementById('outerContainer');
+    document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
+    document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
+    document.getElementById('getArticles')?.addEventListener('click', showListOnClick, false);
 
     chrome.storage.sync.get('userRating', function(result) {
         if (!result?.['userRating']) {
-            outerContainer.innerHTML = startingView;
-            document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
+            const mainView = document.getElementById('mainView');
+            const startingView = document.getElementById('startingView');
+            mainView.style.display = 'none';
+            startingView.style.display = 'block';
         }
     });
 
-    document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
-    document.getElementById('backgroundClick')?.addEventListener('click', bkgOnClick, false);
-    document.getElementById('Urls')?.addEventListener('click', getListOnClick, false);
-
     function setUserRating() {
         // add a slider and allow user to set their value
-        chrome.storage.sync.set({'userRating': 'center'}, function() {
-            outerContainer.innerHTML = mainView;
+        const startingSliderValue = document.getElementById("startingSlider")?.value;
+        const startingToggleChecked = document.getElementById('startingToggle')?.checked;
+        let userAlignment = startingToggleChecked ? 'na' : sliderValueToText(startingSliderValue); // save as the text representation of a political leaning
+        chrome.storage.sync.set({'userRating': userAlignment}, function() {
+            const mainView = document.getElementById('mainView');
+            const startingView = document.getElementById('startingView');
+            mainView.style.display = 'block';
+            startingView.style.display = 'none';
         });
     }
 
@@ -34,15 +30,10 @@ document.addEventListener('DOMContentLoaded', function() {
             chrome.tabs.sendMessage(tabs[0].id, {request: 'toContent'}, null, fromContent);
         });
     }
-    function bkgOnClick() {
-        chrome.tabs.query({currentWindow: true, active: true}, () => {
-            chrome.runtime.sendMessage({request: 'toBkg'}, fromBkg);
-        });
-    }
 
-    function getListOnClick() {
+    function showListOnClick() {
         chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
-            chrome.tabs.sendMessage(tabs[0].id,{request: 'getList'}, null, showList);
+            chrome.tabs.sendMessage(tabs[0].id,{request: 'getArticles'}, null, showArticleList);
         });
     }
 
@@ -63,17 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    function fromBkg(res) {
-        if (res?.currentUrl) {
-            const div = document.createElement('div');
-            div.textContent = res.currentUrl;
-            const br = document.createElement('br');
-            document.body.appendChild(div);
-            document.body.appendChild(br);
-        }
-    }
+    function showArticleList(res) {
 
-    function showList(res) {
         if (res?.listArticles) {
             const listArticles = res.listArticles;
             listArticles.forEach(a => {
@@ -92,11 +74,58 @@ document.addEventListener('DOMContentLoaded', function() {
 
     var slider = document.getElementById("myRange");
     var output = document.getElementById("demo");
-    output.innerHTML = slider.value; // Display the default slider value
+    output.innerHTML = sliderValueToText(slider.value); // Display the default slider value
 
     // Update the current slider value (each time you drag the slider handle)
     slider.oninput = function() {
-    output.innerHTML = this.value;
-}
+        output.innerHTML = sliderValueToText(this.value);
+    }
+
+    // starting view slider:
+    const startingSlider = document.getElementById("startingSlider");
+    const startingSliderOutput = document.getElementById("startingSliderValue");
+    startingSliderOutput.innerHTML = sliderValueToText(startingSlider.value); // Display the default slider value
+    startingSlider.oninput = function() {
+        startingSliderOutput.innerHTML = sliderValueToText(this.value);
+    }
+
+    // starting view toggle:
+    const startingToggleValue = document.getElementById("startingToggle");
+    startingToggleValue.addEventListener('change', function() {
+        const slideContainer = document.getElementById('slideContainer');
+        if(this.checked) {
+            slideContainer.style.display = 'none';
+        } else {
+            slideContainer.style.display = 'block';
+        }
+    });
+    startingSliderOutput.innerHTML = sliderValueToText(startingSlider.value); // Display the default slider value
+    startingSlider.oninput = function() {
+        startingSliderOutput.innerHTML = sliderValueToText(this.value);
+    }
 
 }, false);
+
+function sliderValueToText(sliderValue) {
+    let userAlignment = 'na';
+    switch (sliderValue) {
+        case '0':
+            userAlignment = 'Left';
+            break;
+        case '1':
+            userAlignment = 'Center-left';
+            break;
+        case '2':
+            userAlignment = 'Center';
+            break;
+        case '3':
+            userAlignment = 'Center-right';
+            break;
+        case '4':
+            userAlignment = 'Right';
+            break;
+        default:
+            break;
+    }
+    return userAlignment;
+}

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -16,7 +16,6 @@ document.addEventListener('DOMContentLoaded', function() {
             outerContainer.innerHTML = startingView;
             document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
         }
-        console.log('Value currently is ' + result?.['userRating']);
     });
 
     document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
@@ -24,13 +23,8 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('Urls')?.addEventListener('click', getListOnClick, false);
 
     function setUserRating() {
-        console.log("in set user rating");
         // add a slider and allow user to set their value
         chrome.storage.sync.set({'userRating': 'center'}, function() {
-            console.log('Value is set');
-            chrome.storage.sync.get('userRating', function(result) {
-                console.log('Value is ' + result?.['userRating']);
-            });
             outerContainer.innerHTML = mainView;
         });
     }

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,24 @@
 document.addEventListener('DOMContentLoaded', function() {
 
+    chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
+        if (!result?.value) {
+            const outerContainer = document.getElementById('outerContainer');
+            const childContainer = document.getElementById('childContainer');
+            const startingDiv = `<div id="outerContainer">
+                                        <div>STARTING PAGE</div>
+                                </div>`;
+            outerContainer.innerHTML = startingDiv;
+        }
+        console.log('Value currently is ' + result?.['hasUserUsedNewsSentiment']);
+    });
+
+    chrome.storage.sync.set({'hasUserUsedNewsSentiment': 'NEW VALUE'}, function() {
+        console.log('Value is set');
+        chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
+            console.log('Value is ' + result?.['hasUserUsedNewsSentiment']);
+        });
+    });
+
     document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
     document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
     document.getElementById('Urls').addEventListener('click', getListOnClick, false);

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const startingView = `<div id="outerContainer">
+    const startingView = `<div id="childContainer">
                                         <div>STARTING PAGE</div>
                                         <button id="toMain">click to set user rating to center and enter main</button>
                                 </div>`;

--- a/frontend/popup/popup.js
+++ b/frontend/popup/popup.js
@@ -1,27 +1,39 @@
 document.addEventListener('DOMContentLoaded', function() {
-
-    chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
-        if (!result?.value) {
-            const outerContainer = document.getElementById('outerContainer');
-            const childContainer = document.getElementById('childContainer');
-            const startingDiv = `<div id="outerContainer">
+    const startingView = `<div id="outerContainer">
                                         <div>STARTING PAGE</div>
+                                        <button id="toMain">click to set user rating to center and enter main</button>
                                 </div>`;
-            outerContainer.innerHTML = startingDiv;
+    const mainView = `<div id="childContainer">
+                                    <button id="contentClick">click to get h1 and url from content.js</button>
+                                    <button id="backgroundClick">click for url from background.js</button>
+                                    <button id="dummyURLs">show list of dummy articles</button>
+                                    <script src="popup.js" charset="UTF-8"></script>
+                               </div>`;
+    const outerContainer = document.getElementById('outerContainer');
+
+    chrome.storage.sync.get('userRating', function(result) {
+        if (!result?.['userRating']) {
+            outerContainer.innerHTML = startingView;
+            document.getElementById('toMain')?.addEventListener('click', setUserRating, false);
         }
-        console.log('Value currently is ' + result?.['hasUserUsedNewsSentiment']);
+        console.log('Value currently is ' + result?.['userRating']);
     });
 
-    chrome.storage.sync.set({'hasUserUsedNewsSentiment': 'NEW VALUE'}, function() {
-        console.log('Value is set');
-        chrome.storage.sync.get('hasUserUsedNewsSentiment', function(result) {
-            console.log('Value is ' + result?.['hasUserUsedNewsSentiment']);
+    document.getElementById('contentClick')?.addEventListener('click', contentOnClick, false);
+    document.getElementById('backgroundClick')?.addEventListener('click', bkgOnClick, false);
+    document.getElementById('Urls')?.addEventListener('click', getListOnClick, false);
+
+    function setUserRating() {
+        console.log("in set user rating");
+        // add a slider and allow user to set their value
+        chrome.storage.sync.set({'userRating': 'center'}, function() {
+            console.log('Value is set');
+            chrome.storage.sync.get('userRating', function(result) {
+                console.log('Value is ' + result?.['userRating']);
+            });
+            outerContainer.innerHTML = mainView;
         });
-    });
-
-    document.getElementById('contentClick').addEventListener('click', contentOnClick, false);
-    document.getElementById('backgroundClick').addEventListener('click', bkgOnClick, false);
-    document.getElementById('Urls').addEventListener('click', getListOnClick, false);
+    }
 
     function contentOnClick() {
         chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
   "options_page": "frontend/options.html",
   "permissions": [
     "tabs",
+    "storage",
     "https://*/*",
     "http://*/*",
     "<all_urls>"


### PR DESCRIPTION
Added a 'first view' where users can set their political preference before entering the main view. Currently, the values are stored as either 'na', 'left', 'center-left', 'center', 'center-right', or 'right' in chrome.storage.sync (the developer panel doesn't seem show show this - might have to download the Storage Area Explorer extension to see or delete this data (there is no way currently to change a user's preference from the GUI). 

I was wondering if we wanted to store the data numerically (e.g. 0-4 or 1-5, etc) vs the strings (as they are currently stored in this PR). I currently have them stored as strings because of the addition of the 'na' option.

closes #45 